### PR TITLE
Feature/test client

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -5,6 +5,6 @@ go 1.13
 require (
 	github.com/davecgh/go-spew v1.1.1 // indirect
 	github.com/pkg/errors v0.9.1
-	github.com/stretchr/testify v1.5.1
-	gopkg.in/yaml.v2 v2.3.0 // indirect
+	github.com/stretchr/testify v1.6.1
+	gopkg.in/yaml.v3 v3.0.0-20200615113413-eeeca48fe776 // indirect
 )

--- a/go.sum
+++ b/go.sum
@@ -8,11 +8,11 @@ github.com/pmezard/go-difflib v1.0.0 h1:4DBwDE0NGyQoBHbLQYPwSUPoCMWR5BEzIk/f1lZb
 github.com/pmezard/go-difflib v1.0.0/go.mod h1:iKH77koFhYxTK1pcRnkKkqfTogsbg7gZNVY4sRDYZ/4=
 github.com/stretchr/objx v0.1.0 h1:4G4v2dO3VZwixGIRoQ5Lfboy6nUhCyYzaqnIAPPhYs4=
 github.com/stretchr/objx v0.1.0/go.mod h1:HFkY916IF+rwdDfMAkV7OtwuqBVzrE8GR6GFx+wExME=
-github.com/stretchr/testify v1.5.1 h1:nOGnQDM7FYENwehXlg/kFVnos3rEvtKTjRvOWSzb6H4=
-github.com/stretchr/testify v1.5.1/go.mod h1:5W2xD1RspED5o8YsWQXVCued0rvSQ+mT+I5cxcmMvtA=
+github.com/stretchr/testify v1.6.1 h1:hDPOHmpOpP40lSULcqw7IrRb/u7w6RpDC9399XyoNd0=
+github.com/stretchr/testify v1.6.1/go.mod h1:6Fq8oRcR53rry900zMqJjRRixrwX3KX962/h/Wwjteg=
 gopkg.in/check.v1 v0.0.0-20161208181325-20d25e280405 h1:yhCVgyC4o1eVCa2tZl7eS0r+SDo693bJlVdllGtEeKM=
 gopkg.in/check.v1 v0.0.0-20161208181325-20d25e280405/go.mod h1:Co6ibVJAznAaIkqp8huTwlJQCZ016jof/cbN4VW5Yz0=
-gopkg.in/yaml.v2 v2.2.2 h1:ZCJp+EgiOT7lHqUV2J862kp8Qj64Jo6az82+3Td9dZw=
-gopkg.in/yaml.v2 v2.2.2/go.mod h1:hI93XBmqTisBFMUTm0b8Fm+jr3Dg1NNxqwp+5A1VGuI=
-gopkg.in/yaml.v2 v2.3.0 h1:clyUAQHOM3G0M3f5vQj7LuJrETvjVot3Z5el9nffUtU=
-gopkg.in/yaml.v2 v2.3.0/go.mod h1:hI93XBmqTisBFMUTm0b8Fm+jr3Dg1NNxqwp+5A1VGuI=
+gopkg.in/yaml.v3 v3.0.0-20200313102051-9f266ea9e77c h1:dUUwHk2QECo/6vqA44rthZ8ie2QXMNeKRTHCNY2nXvo=
+gopkg.in/yaml.v3 v3.0.0-20200313102051-9f266ea9e77c/go.mod h1:K4uyk7z7BCEPqu6E+C64Yfv1cQ7kz7rIZviUmN+EgEM=
+gopkg.in/yaml.v3 v3.0.0-20200615113413-eeeca48fe776 h1:tQIYjPdBoyREyB9XMu+nnTclpTYkz2zFM+lzLJFO4gQ=
+gopkg.in/yaml.v3 v3.0.0-20200615113413-eeeca48fe776/go.mod h1:K4uyk7z7BCEPqu6E+C64Yfv1cQ7kz7rIZviUmN+EgEM=

--- a/internal/common/client.go
+++ b/internal/common/client.go
@@ -7,7 +7,16 @@ import (
 
 type AuthFunc func(string) url.Values
 
+//NewClientWithURL allows creating a new Client with a hardcoded URL. Useful for testing purposes
+func NewClientWithURL(sk, cc, partnerKey, url string, httpCli *http.Client, headersForEveryRequestFunc AuthFunc) *Client {
+	return newClientFull(sk, cc, partnerKey, url, httpCli, headersForEveryRequestFunc)
+}
+
 func NewClient(sk, cc, partnerKey string, httpCli *http.Client, headersForEveryRequestFunc AuthFunc) *Client {
+	return newClientFull(sk, cc, partnerKey, "", httpCli, headersForEveryRequestFunc)
+}
+
+func newClientFull(sk, cc, partnerKey, url string, httpCli *http.Client, headersForEveryRequestFunc AuthFunc) *Client {
 	if httpCli == nil {
 		httpCli = GetDefaultHTTPClient()
 	}
@@ -22,10 +31,14 @@ func NewClient(sk, cc, partnerKey string, httpCli *http.Client, headersForEveryR
 	if cli.headersFunc == nil {
 		cli.headersFunc = cli.getDefaultMandatoryHeaders
 	}
-	if cc != "" {
-		cli.Url = GetBaseURL(cc)
+	if url == "" {
+		if cc != "" {
+			cli.Url = GetBaseURL(cc)
+		} else {
+			cli.Url = GetBaseURLFromAuthFunc(cli.headersFunc)
+		}
 	} else {
-		cli.Url = GetBaseURLFromAuthFunc(cli.headersFunc)
+		cli.Url = url
 	}
 	return cli
 }

--- a/pkg/api/client.go
+++ b/pkg/api/client.go
@@ -2,10 +2,11 @@ package api
 
 import (
 	"errors"
-	"github.com/erply/api-go-wrapper/pkg/api/documents"
-	"github.com/erply/api-go-wrapper/pkg/api/prices"
 	"net/http"
 	"net/url"
+
+	"github.com/erply/api-go-wrapper/pkg/api/documents"
+	"github.com/erply/api-go-wrapper/pkg/api/prices"
 
 	"github.com/erply/api-go-wrapper/internal/common"
 	"github.com/erply/api-go-wrapper/pkg/api/addresses"
@@ -71,6 +72,15 @@ func NewClientWithCustomHeaders(customHTTPCli *http.Client, headersSetToEveryReq
 		return nil, errors.New("the function that will set headers to every request is a required argument")
 	}
 	return newErplyClient(common.NewClient("", "", "", customHTTPCli, headersSetToEveryRequest)), nil
+}
+
+//NewClientWithURL creates a new Client which can have a static URL which is not affected by clientCode
+// nor the headersSetToEveryRequest function if set. If the url parameter is set to an empty string, the URL
+// is still resolved normally. This allows creating clients which have a static url in your unit tests but function
+// normally in the rest of your code
+func NewClientWithURL(sk, cc, partnerKey, url string, httpCli *http.Client, headersSetToEveryRequest func(requestName string) url.Values) *Client {
+	comCli := common.NewClientWithURL(sk, cc, partnerKey, url, httpCli, headersSetToEveryRequest)
+	return newErplyClient(comCli)
 }
 
 func newErplyClient(c *common.Client) *Client {

--- a/pkg/api/client.go
+++ b/pkg/api/client.go
@@ -78,9 +78,12 @@ func NewClientWithCustomHeaders(customHTTPCli *http.Client, headersSetToEveryReq
 // nor the headersSetToEveryRequest function if set. If the url parameter is set to an empty string, the URL
 // is still resolved normally. This allows creating clients which have a static url in your unit tests but function
 // normally in the rest of your code
-func NewClientWithURL(sk, cc, partnerKey, url string, httpCli *http.Client, headersSetToEveryRequest func(requestName string) url.Values) *Client {
-	comCli := common.NewClientWithURL(sk, cc, partnerKey, url, httpCli, headersSetToEveryRequest)
-	return newErplyClient(comCli)
+func NewClientWithURL(sessionKey, clientCode, partnerKey, url string, httpCli *http.Client, headersSetToEveryRequest func(requestName string) url.Values) (*Client, error) {
+	if (sessionKey == "" || clientCode == "") && headersSetToEveryRequest == nil {
+		return nil, errors.New("Either sessionKey and clientCode or a function for header generation is required")
+	}
+	comCli := common.NewClientWithURL(sessionKey, clientCode, partnerKey, url, httpCli, headersSetToEveryRequest)
+	return newErplyClient(comCli), nil
 }
 
 func newErplyClient(c *common.Client) *Client {


### PR DESCRIPTION
This pull requests allows creating Clients with a static URL. 

It is necessary because common.Client and its internal state are not available outside of this library but mocking the Erply API is useful in unit tests. 

go mod tidy also upgraded the yaml library to next major version. Not my intention but looks harmless enough so i'd just roll with it