### PR TITLE
Pass filters to getWarehouses

### DIFF
--- a/pkg/api/warehouse/interface.go
+++ b/pkg/api/warehouse/interface.go
@@ -4,7 +4,7 @@ import "context"
 
 type (
 	Manager interface {
-		GetWarehouses(ctx context.Context) (Warehouses, error)
+		GetWarehouses(ctx context.Context, filters map[string]string) (Warehouses, error)
 		GetWarehousesBulk(
 			ctx context.Context,
 			bulkRequest []map[string]interface{},

--- a/pkg/api/warehouse/warehouse.go
+++ b/pkg/api/warehouse/warehouse.go
@@ -10,8 +10,8 @@ import (
 )
 
 //GetWarehouses ...
-func (cli *Client) GetWarehouses(ctx context.Context) (Warehouses, error) {
-	resp, err := cli.SendRequest(ctx, "getWarehouses", map[string]string{"warehouseID": "0"})
+func (cli *Client) GetWarehouses(ctx context.Context, filters map[string]string) (Warehouses, error) {
+	resp, err := cli.SendRequest(ctx, "getWarehouses", filters)
 	if err != nil {
 		return nil, err
 	}


### PR DESCRIPTION
Made getwarehouses more flexible and more useful by allowing to pass a filters map instead of hard coded get warehouse ID 0