### PR TITLE
Address.typeID support for unmarshalling both string and int values

### DIFF
--- a/pkg/api/common/sharedModels.go
+++ b/pkg/api/common/sharedModels.go
@@ -1,24 +1,30 @@
 package common
 
+import (
+	"encoding/json"
+	"fmt"
+	"strconv"
+)
+
 type (
 	//Addresses from getAddresses
 	Addresses []Address
 
 	//Address from getAddresses
 	Address struct {
-		AddressID        int    `json:"addressID"`
-		OwnerID          int    `json:"ownerID"`
-		TypeID           int    `json:"typeID"`
-		TypeActivelyUsed int    `json:"typeActivelyUsed"`
-		Added            int64  `json:"added"`
-		Address2         string `json:"address2"`
-		TypeName         string `json:"typeName"`
-		Address          string `json:"address"`
-		Street           string `json:"street"`
-		PostalCode       string `json:"postalCode"`
-		City             string `json:"city"`
-		State            string `json:"state"`
-		Country          string `json:"country"`
+		AddressID        int
+		OwnerID          int
+		TypeID           int
+		TypeActivelyUsed int
+		Added            int64
+		Address2         string
+		TypeName         string
+		Address          string
+		Street           string
+		PostalCode       string
+		City             string
+		State            string
+		Country          string
 		LastModified
 		Attributes
 	}
@@ -48,3 +54,58 @@ type (
 		LastModifierUsername   string `json:"lastModifierUsername"`
 	}
 )
+
+func (u *Address) UnmarshalJSON(data []byte) error {
+
+	raw := struct {
+		AddressID        int    `json:"addressID"`
+		OwnerID          int    `json:"ownerID"`
+		TypeID           interface{}    `json:"typeID"`
+		TypeActivelyUsed int    `json:"typeActivelyUsed"`
+		Added            int64  `json:"added"`
+		Address2         string `json:"address2"`
+		TypeName         string `json:"typeName"`
+		Address          string `json:"address"`
+		Street           string `json:"street"`
+		PostalCode       string `json:"postalCode"`
+		City             string `json:"city"`
+		State            string `json:"state"`
+		Country          string `json:"country"`
+		LastModified
+		Attributes
+	}{}
+	err := json.Unmarshal(data, &raw)
+	if err != nil {
+		return err
+	}
+
+	u.AddressID = raw.AddressID
+	u.OwnerID = raw.OwnerID
+
+	switch v := raw.TypeID.(type) {
+	case int:
+		u.TypeID = v
+	case float64:
+		u.TypeID = int(v)
+	case string:
+		i, err := strconv.Atoi(v)
+		if err != nil {
+			return fmt.Errorf("unable to unmarshal address. typeId did not contain an int: %s", v)
+		}
+		u.TypeID = i
+	}
+
+	u.TypeActivelyUsed = raw.TypeActivelyUsed
+	u.Added = raw.Added
+	u.Address2 = raw.Address2
+	u.TypeName = raw.TypeName
+	u.Address = raw.Address
+	u.Street = raw.Street
+	u.PostalCode = raw.PostalCode
+	u.City = raw.City
+	u.State = raw.State
+	u.Country = raw.Country
+	u.LastModified = raw.LastModified
+	u.Attributes = raw.Attributes
+	return nil
+}


### PR DESCRIPTION
The Erply API returns inconsistently typed values for the Address type. In case of the GetAddresses call, the typeID field is correctly an int. However in the GetCustomers call, the addresses included in the structure contain typeID-s that are types as strings (even though the Erply API spec lists that they should be also int-s). This means that unmarshalling GetCustomers responses which contain address substructures can result in an error due to the incorrect data type.

Due to backward compatibility concerns it is not possible to fix the issue on the Eply API side.

As a solution I have implemented a custom unmarshaller for the Address type. It will parse both ints and strings into the existing Address structure field typeID. Existing users should not be affected.