### PR TITLE
Changed calculateShoppingCart field vatRate type to match API impl in…

### DIFF
--- a/pkg/api/sales/shoppingCartModels.go
+++ b/pkg/api/sales/shoppingCartModels.go
@@ -12,7 +12,7 @@ type ShoppingCartProduct struct {
 	ProductID            string  `json:"productID"`
 	Amount               string  `json:"amount"`
 	VatRateID            int     `json:"vatrateID"`
-	VatRate              float64 `json:"vatRate"`
+	VatRate              string  `json:"vatRate"`
 	OriginalPrice        float64 `json:"originalPrice"`
 	OriginalPriceWithVAT float64 `json:"originalPriceWithVAT"`
 	PromotionDiscount    float64 `json:"promotionDiscount"`


### PR DESCRIPTION
vatRate field is listed as decimal in spec but is actually a string in API response. So changing wrapper field datatype type also to string